### PR TITLE
add to handle argv input

### DIFF
--- a/SSD/SSD-DirtySweeper/main.cpp
+++ b/SSD/SSD-DirtySweeper/main.cpp
@@ -85,9 +85,27 @@ TEST_F(SSDTest, WriteFailWithOutOfAddressRange) {
     EXPECT_FALSE(isPass);
 }
 
+#ifdef NDEBUG
+int main(int argc, char *argv[])
+{
+    SSD ssd;
+    string inputLine;
 
+    // skip ssd.exe myself
+    for (int i = 1; i < argc; ++i) {
+        if (i > 1) inputLine += " ";
+        inputLine += argv[i];
+    }
+
+    ssd.commandParser(inputLine);
+    ssd.exec();
+
+    return 0;
+}
+#else
 int main()
 {
     ::testing::InitGoogleMock();
     return RUN_ALL_TESTS();
 }
+#endif

--- a/SSD/SSD-DirtySweeper/ssd.cpp
+++ b/SSD/SSD-DirtySweeper/ssd.cpp
@@ -85,6 +85,13 @@ public:
 		op = arg;
 	}
 
+	bool exec() {
+		if (op == "R")
+			return readData(addr);
+		if (op == "W")
+			return writeData(addr, value);
+	}
+
 	int argCount;
 	string op;
 	int addr;


### PR DESCRIPTION
release version에서는 ./ssd.exe R 3 처럼 argc/argv로 main에서 받아 처리해야 합니다.
따라서 NDEBUG 전처리기 사용하여 release version에서는 argc/argv로 input을 받아 처리하는 부분 추가하였습니다. 
