### PR TITLE
Feature/testshell bugfix

### DIFF
--- a/TestShell/TestShell-DirtySweeper/testShell.cpp
+++ b/TestShell/TestShell-DirtySweeper/testShell.cpp
@@ -258,11 +258,11 @@ public:
             string endLBAResult = readOutputFile();
 
             if (firstLBAResult != endLBAResult) {
-                cout << "FAIL";
+                cout << "FAIL\n";
                 return;
             }
         }
-        cout << "PASS";
+        cout << "PASS\n";
     }
 
     virtual std::string generateRandomHexString() {

--- a/TestShell/TestShell-DirtySweeper/testShell.cpp
+++ b/TestShell/TestShell-DirtySweeper/testShell.cpp
@@ -79,7 +79,7 @@ public:
 
     void executeCommand(const std::string& cmd, const std::vector<std::string>& args) {
         if (cmd == "read") {
-            if (args.size() < 1) {
+            if ((args.size() == 0) || (args.size() >= 2)) {
                 std::cout << "INVALID COMMAND\n";
                 return;
             }
@@ -89,6 +89,10 @@ public:
         }
 
         if (cmd == "fullread") {
+            if (args.size() > 0) {
+                std::cout << "INVALID COMMAND\n";
+                return;
+            }
             this->fullRead();
             return;
         }

--- a/TestShell/TestShell-DirtySweeper/testShell.cpp
+++ b/TestShell/TestShell-DirtySweeper/testShell.cpp
@@ -167,10 +167,13 @@ public:
     }
 
     void read(int lba) {
-        if (lba < 0 || lba > 99) throw std::exception();
+        if (lba < 0 || lba > 99) {
+            printErrorReadResult();
+            return;
+        }
         ssd->read(lba);
         std::string result = readOutputFile();
-        if (result == "ERROR") printErrorReadResult(result);
+        if (result == "ERROR") printErrorReadResult();
         else printSuccessReadResult(result, lba);
     }
 
@@ -179,7 +182,7 @@ public:
             ssd->read(lba);
             std::string result = readOutputFile();
             if (result == "ERROR") {
-                printErrorReadResult(result);
+                printErrorReadResult();
                 break;
             }
             printSuccessReadResult(result, lba);
@@ -331,7 +334,7 @@ private:
     virtual std::string readOutputFile() {
         std::ifstream file("..\\..\\SSD\\x64\\Release\\ssd_output.txt");
 
-        if (!file.is_open()) throw std::exception();
+        if (!file.is_open()) throw std::runtime_error("File not open: ssd_output.txt");
 
         std::ostringstream content;
         std::string line;
@@ -363,8 +366,8 @@ private:
         return valid.count(cmd) > 0;
     }
 
-    void printErrorReadResult(std::string result) {
-        std::cout << "[Read] " << result << "\n";
+    void printErrorReadResult() {
+        std::cout << "[Read] ERROR\n";
     }
 
     void printSuccessReadResult(std::string result, int lba) {

--- a/TestShell/TestShell-DirtySweeper/testShell.cpp
+++ b/TestShell/TestShell-DirtySweeper/testShell.cpp
@@ -119,6 +119,10 @@ public:
         }
 
         if (cmd == "fullwrite") {
+            if ((args.size() <= 0) || (args.size() >= 2)) {
+                std::cout << "INVALID COMMAND\n";
+                return;
+            }
             std::string data = args[0];
             this->fullWrite(data);
             return;
@@ -206,21 +210,17 @@ public:
         return WRITE_SUCCESS_MESSAGE;
     }
 
-    string fullWrite(string data)
+    void fullWrite(string data)
     {
-        string totalResult = "";
         for (int lba = LBA_START_ADDRESS; lba <= LBA_END_ADDRESS; lba++) {
             ssd->write(lba, data);
             string currentResult = readOutputFile();
             if (currentResult == "ERROR") {
-                totalResult += WRITE_ERROR_MESSAGE;
-                printErrorWriteResult();
-                break;
+                cout << "[Full Write] ERROR\n";
+                return;
             }
-            totalResult += WRITE_SUCCESS_MESSAGE + "\n";
-            printSuccessWriteResult();
         }
-        return totalResult;
+        cout << "[Full Write] Done\n";;
     }
 
     std::string getWriteDataInFullWriteAndReadCompareScript(int lba){

--- a/TestShell/TestShell-DirtySweeper/testShell.cpp
+++ b/TestShell/TestShell-DirtySweeper/testShell.cpp
@@ -239,8 +239,11 @@ public:
 
             if (readData != writeData) {
                 std::cout << "[Mismatch] LBA " << lba << " Expected: " << writeData << " Got: " << readData << "\n";
+                std::cout << "FAIL\n";
+                return;
             }
         }
+        std::cout << "PASS\n";
     }
 
     void exit(void) {

--- a/TestShell/TestShell-DirtySweeper/testShell_read_test.cpp
+++ b/TestShell/TestShell-DirtySweeper/testShell_read_test.cpp
@@ -24,7 +24,17 @@ TEST_F(ReadTestFixture, BasicRead) {
 }
 
 TEST_F(ReadTestFixture, InvalidAddress) {
-	EXPECT_THROW(testShell.read(100), std::exception);
+	EXPECT_CALL(ssdMock, read(_))
+		.Times(0);
+
+	EXPECT_CALL(testShell, readOutputFile())
+		.Times(0);
+
+	testing::internal::CaptureStdout();
+	testShell.read(100);
+	std::string output = testing::internal::GetCapturedStdout();
+	cout << output;
+	EXPECT_THAT(output, ::testing::HasSubstr("ERROR"));
 }
 
 TEST_F(ReadTestFixture, ReadSuccessTest) {

--- a/TestShell/TestShell-DirtySweeper/testShell_script_test.cpp
+++ b/TestShell/TestShell-DirtySweeper/testShell_script_test.cpp
@@ -58,8 +58,10 @@ TEST_F(FullWriteReadTest, FullWriteAndReadCompareShouldPass) {
 TEST_F(FullWriteReadTest, FullWriteAndReadCompareShouldFail) {
     std::string evenData = EVEN_DATA;
     std::string oddData = ODD_DATA;
+    const int ERROR_INJECTED_LBA = 13;
 
     for (int lbaIndex = START_LBA; lbaIndex <= END_LBA; ++lbaIndex) {
+        if (lbaIndex > ERROR_INJECTED_LBA) break;
         std::string data = (lbaIndex / 5 % 2 == 0) ? evenData : oddData;
         EXPECT_CALL(ssd, write(lbaIndex, data)).Times(1);
         EXPECT_CALL(ssd, read(lbaIndex)).Times(1);
@@ -68,8 +70,9 @@ TEST_F(FullWriteReadTest, FullWriteAndReadCompareShouldFail) {
     Sequence seq;
     for (int lbaIndex = START_LBA; lbaIndex <= END_LBA; ++lbaIndex) {
         std::string expected;
+        if (lbaIndex > ERROR_INJECTED_LBA) break;
 
-        if (lbaIndex == 13) {
+        if (lbaIndex == ERROR_INJECTED_LBA) {
             // 일부러 실패하도록 의도적으로 잘못된 값
             expected = "0xWRONGDATA";
         }

--- a/TestShell/TestShell-DirtySweeper/testShell_write_test.cpp
+++ b/TestShell/TestShell-DirtySweeper/testShell_write_test.cpp
@@ -76,8 +76,11 @@ TEST_F(TestShellWriteTest, FullWriteNormalCase)
         .Times(100)
         .WillRepeatedly(Return(SSD_WRITE_DONE_VALUE));
 
-    string result = sut.fullWrite(VALID_DATA);
-    EXPECT_EQ(actual, result);
+    testing::internal::CaptureStdout();
+    sut.fullWrite(VALID_DATA);
+    std::string output = testing::internal::GetCapturedStdout();
+    cout << output;
+    EXPECT_THAT(output, ::testing::HasSubstr("[Full Write] Done"));
 }
 TEST_F(TestShellWriteTest, FullWriteFailWithInvalidData)
 {
@@ -89,8 +92,11 @@ TEST_F(TestShellWriteTest, FullWriteFailWithInvalidData)
         .Times(1)
         .WillRepeatedly(Return(SSD_WRITE_ERROR_VALUE));
 
-    string result = sut.fullWrite(INVALID_DATA);
-    EXPECT_EQ(WRITE_FAIL_RESULT, result);
+    testing::internal::CaptureStdout();
+    sut.fullWrite(INVALID_DATA);
+    std::string output = testing::internal::GetCapturedStdout();
+    cout << output;
+    EXPECT_THAT(output, ::testing::HasSubstr("[Full Write] ERROR"));
 }
 
 


### PR DESCRIPTION
# Testshell 기본 기능 Bugfix
1. read에서 invalid parameter일 때 [Read] ERROR 가 출력되어야하는데 exception 으로 출력되는 문제 수정
2. 3번 스크립트 성공 후 PASS /FAIL 뒤에 '\n' 추가
3. fullread 뒤에 invalid한게 붙어도 지금은 fullread가 정상 수행되는 것 수정 - argument 추가로 받을 경우 INVALID COMMAND 처리
4. 1번 스크립트 성공 후 PASS /FAIL 출력 추가
5. fullwrite 끝나고는 [Full Write] Done 또는 [Full Write] ERROR 로 최종 결과만 출력하도록 변경