### PR TITLE
[Design Pattern] Buffered SSD 를 Proxy pattern 으로 적용

### DIFF
--- a/SSD/SSD-DirtySweeper/main.cpp
+++ b/SSD/SSD-DirtySweeper/main.cpp
@@ -6,7 +6,7 @@ using std::string;
 
 class SSDTest : public ::testing::Test {
 public:
-    SSD ssd;
+    SSD* ssd = new BufferedSSD();
     ReadCommand readCmd;
     WriteCommand writeCmd;
     EraseCommand eraseCmd;
@@ -80,40 +80,40 @@ TEST_F(SSDTest, ReadTC_ReturnData02)
 
 TEST_F(SSDTest, ArgparseRead) {
     string cmd = buildCommand("R", 3);
-    ssd.parseCommand(cmd);
-    EXPECT_EQ(2, ssd.getArgCount());
-    EXPECT_EQ("R", ssd.getOp());
-    EXPECT_EQ(3, ssd.getAddr());
+    ssd->parseCommand(cmd);
+    EXPECT_EQ(2, ssd->getArgCount());
+    EXPECT_EQ("R", ssd->getOp());
+    EXPECT_EQ(3, ssd->getAddr());
 }
 
 TEST_F(SSDTest, ArgparseWrite)
 {
     string cmd = buildCommand("W", 3, VALID_HEX_DATA);
-    ssd.parseCommand(cmd);
-    EXPECT_EQ(3, ssd.getArgCount());
-    EXPECT_EQ("W", ssd.getOp());
-    EXPECT_EQ(3, ssd.getAddr());
-    EXPECT_EQ("0x1298CDEF", ssd.getValue());
+    ssd->parseCommand(cmd);
+    EXPECT_EQ(3, ssd->getArgCount());
+    EXPECT_EQ("W", ssd->getOp());
+    EXPECT_EQ(3, ssd->getAddr());
+    EXPECT_EQ("0x1298CDEF", ssd->getValue());
 }
 
 TEST_F(SSDTest, ArgparseInvalidOp)
 {
     string cmd = buildCommand("S", 3);
-    ssd.parseCommand(cmd);
+    ssd->parseCommand(cmd);
     EXPECT_TRUE(checkOutputFile("ERROR"));
 }
 
 TEST_F(SSDTest, ArgparseInvalidAddr)
 {
     string cmd = buildCommand("R", 300);
-    ssd.parseCommand(cmd);
+    ssd->parseCommand(cmd);
     EXPECT_TRUE(checkOutputFile("ERROR"));
 }
 
 TEST_F(SSDTest, ArgparseInvalidValue)
 {
     string cmd = buildCommand("W", 3, INVALID_HEX_DATA);
-    ssd.parseCommand(cmd);
+    ssd->parseCommand(cmd);
     EXPECT_TRUE(checkOutputFile("ERROR"));
 }
 
@@ -181,7 +181,7 @@ TEST_F(SSDTest, WriteReadVerify00) {
 #ifdef NDEBUG
 int main(int argc, char *argv[])
 {
-    SSD ssd;
+    SSD* ssd = new BufferedSSD();
     string inputLine;
 
     // skip ssd.exe myself
@@ -190,9 +190,9 @@ int main(int argc, char *argv[])
         inputLine += argv[i];
     }
 
-    if (!ssd.parseCommand(inputLine))
+    if (!ssd->parseCommand(inputLine))
         return -1;
-    ssd.exec();
+    ssd->exec();
 
     return 0;
 }

--- a/SSD/SSD-DirtySweeper/main.cpp
+++ b/SSD/SSD-DirtySweeper/main.cpp
@@ -4,7 +4,182 @@
 
 using std::string;
 
-class SSDTest : public ::testing::Test {
+class RealSSDTest : public ::testing::Test {
+public:
+    SSD* ssd = new RealSSD();
+    ReadCommand readCmd;
+    WriteCommand writeCmd;
+    EraseCommand eraseCmd;
+    string VALID_HEX_DATA = "0x1298CDEF";
+    string INVALID_HEX_DATA = "0xABCDEFGH";
+    string INITIAL_HEX_DATA = "0x00000000";
+    static const int VALID_TEST_ADDRESS = 0;
+    static const int INVALID_TEST_ADDRESS = 100;
+
+    void SetUp() override {
+        eraseCmd.run();
+    }
+
+    bool checkOutputFile(string expected) {
+        ifstream fin(FileNames::OUTPUT_FILE);
+        if (!fin.is_open()) {
+            cout << "OUTPUT file open failed\n";
+            return false;
+        }
+
+        string line;
+        getline(fin, line);
+        if (line != expected)
+            return false;
+        return true;
+    }
+
+    string buildCommand(string rw, int lba, string data = "") {
+        string cmdLine = rw + " " + std::to_string(lba);
+        if (rw == "W") cmdLine = cmdLine + " " + data;
+        return cmdLine;
+    }
+};
+
+
+TEST_F(RealSSDTest, ReadTC_InitialValue)
+{
+    int lba_addr = 1;
+    bool isPass;
+    isPass = readCmd.run(lba_addr);
+    EXPECT_EQ(true, isPass);
+	EXPECT_TRUE(checkOutputFile(INITIAL_HEX_DATA));
+}
+
+TEST_F(RealSSDTest, ReadTC_OutofRange)
+{
+    int lba_addr = 100;
+    bool isPass;
+    isPass = readCmd.run(lba_addr);
+    EXPECT_EQ(false, isPass);
+    EXPECT_TRUE(checkOutputFile("ERROR"));
+}
+
+TEST_F(RealSSDTest, ReadTC_ReturnData01)
+{
+    int lba_addr = 50;
+    bool isPass;
+    isPass = readCmd.run(lba_addr);
+    EXPECT_EQ(true, isPass);
+    EXPECT_TRUE(checkOutputFile(INITIAL_HEX_DATA));
+}
+
+TEST_F(RealSSDTest, ReadTC_ReturnData02)
+{
+    int lba_addr = 30;
+    bool isPass;
+    isPass = readCmd.run(lba_addr);
+    EXPECT_EQ(true, isPass);
+    EXPECT_TRUE(checkOutputFile(INITIAL_HEX_DATA));
+}
+
+TEST_F(RealSSDTest, ArgparseRead) {
+    string cmd = buildCommand("R", 3);
+    ssd->parseCommand(cmd);
+    EXPECT_EQ(2, ssd->getArgCount());
+    EXPECT_EQ("R", ssd->getOp());
+    EXPECT_EQ(3, ssd->getAddr());
+}
+
+TEST_F(RealSSDTest, ArgparseWrite)
+{
+    string cmd = buildCommand("W", 3, VALID_HEX_DATA);
+    ssd->parseCommand(cmd);
+    EXPECT_EQ(3, ssd->getArgCount());
+    EXPECT_EQ("W", ssd->getOp());
+    EXPECT_EQ(3, ssd->getAddr());
+    EXPECT_EQ("0x1298CDEF", ssd->getValue());
+}
+
+TEST_F(RealSSDTest, ArgparseInvalidOp)
+{
+    string cmd = buildCommand("S", 3);
+    ssd->parseCommand(cmd);
+    EXPECT_TRUE(checkOutputFile("ERROR"));
+}
+
+TEST_F(RealSSDTest, ArgparseInvalidAddr)
+{
+    string cmd = buildCommand("R", 300);
+    ssd->parseCommand(cmd);
+    EXPECT_TRUE(checkOutputFile("ERROR"));
+}
+
+TEST_F(RealSSDTest, ArgparseInvalidValue)
+{
+    string cmd = buildCommand("W", 3, INVALID_HEX_DATA);
+    ssd->parseCommand(cmd);
+    EXPECT_TRUE(checkOutputFile("ERROR"));
+}
+
+TEST_F(RealSSDTest, WritePass) {
+    bool isPass = writeCmd.run(VALID_TEST_ADDRESS, VALID_HEX_DATA);
+    EXPECT_TRUE(isPass);
+}
+
+TEST_F(RealSSDTest, WriteFailWithOutOfAddressRange) {
+    bool isPass = writeCmd.run(INVALID_TEST_ADDRESS, VALID_HEX_DATA);
+    EXPECT_FALSE(isPass);
+}
+
+
+TEST_F(RealSSDTest, WriteInvalidData00) {
+
+    string invalidData = "0x1234567890000";
+    bool isPass = writeCmd.run(VALID_TEST_ADDRESS, invalidData);
+    EXPECT_FALSE(isPass);
+}
+
+TEST_F(RealSSDTest, WriteInvalidData01) {
+
+    string invalidData = "0x1234";
+    bool isPass = writeCmd.run(VALID_TEST_ADDRESS, invalidData);
+    EXPECT_FALSE(isPass);
+}
+
+TEST_F(RealSSDTest, WriteInvalidData02) {
+
+    string invalidData = "12345678";
+    bool isPass = writeCmd.run(VALID_TEST_ADDRESS, invalidData);
+    EXPECT_FALSE(isPass);
+}
+
+TEST_F(RealSSDTest, WriteInvalidData03) {
+
+    string invalidData = "0x1234ABzE";
+    bool isPass = writeCmd.run(VALID_TEST_ADDRESS, invalidData);
+    EXPECT_FALSE(isPass);
+}
+
+TEST_F(RealSSDTest, WriteInvalidData04) {
+
+    string invalidData = "0xA5CCH012";
+    bool isPass = writeCmd.run(VALID_TEST_ADDRESS, invalidData);
+    EXPECT_FALSE(isPass);
+}
+
+TEST_F(RealSSDTest, WriteReadVerify00) {
+
+    bool isPass = readCmd.run(VALID_TEST_ADDRESS);
+
+    EXPECT_EQ(true, isPass);
+    EXPECT_TRUE(checkOutputFile(INITIAL_HEX_DATA));
+
+    isPass = writeCmd.run(VALID_TEST_ADDRESS, VALID_HEX_DATA);
+    EXPECT_TRUE(isPass);
+
+    isPass = readCmd.run(VALID_TEST_ADDRESS);
+    EXPECT_EQ(true, isPass);
+    EXPECT_TRUE(checkOutputFile(VALID_HEX_DATA));
+}
+
+
+class BufferedSSDTest : public ::testing::Test {
 public:
     SSD* ssd = new BufferedSSD();
     ReadCommand readCmd;
@@ -41,17 +216,16 @@ public:
     }
 };
 
-
-TEST_F(SSDTest, ReadTC_InitialValue)
+TEST_F(BufferedSSDTest, ReadTC_InitialValue)
 {
     int lba_addr = 1;
     bool isPass;
     isPass = readCmd.run(lba_addr);
     EXPECT_EQ(true, isPass);
-	EXPECT_TRUE(checkOutputFile(INITIAL_HEX_DATA));
+    EXPECT_TRUE(checkOutputFile(INITIAL_HEX_DATA));
 }
 
-TEST_F(SSDTest, ReadTC_OutofRange)
+TEST_F(BufferedSSDTest, ReadTC_OutofRange)
 {
     int lba_addr = 100;
     bool isPass;
@@ -60,7 +234,7 @@ TEST_F(SSDTest, ReadTC_OutofRange)
     EXPECT_TRUE(checkOutputFile("ERROR"));
 }
 
-TEST_F(SSDTest, ReadTC_ReturnData01)
+TEST_F(BufferedSSDTest, ReadTC_ReturnData01)
 {
     int lba_addr = 50;
     bool isPass;
@@ -69,7 +243,7 @@ TEST_F(SSDTest, ReadTC_ReturnData01)
     EXPECT_TRUE(checkOutputFile(INITIAL_HEX_DATA));
 }
 
-TEST_F(SSDTest, ReadTC_ReturnData02)
+TEST_F(BufferedSSDTest, ReadTC_ReturnData02)
 {
     int lba_addr = 30;
     bool isPass;
@@ -78,7 +252,7 @@ TEST_F(SSDTest, ReadTC_ReturnData02)
     EXPECT_TRUE(checkOutputFile(INITIAL_HEX_DATA));
 }
 
-TEST_F(SSDTest, ArgparseRead) {
+TEST_F(BufferedSSDTest, ArgparseRead) {
     string cmd = buildCommand("R", 3);
     ssd->parseCommand(cmd);
     EXPECT_EQ(2, ssd->getArgCount());
@@ -86,7 +260,7 @@ TEST_F(SSDTest, ArgparseRead) {
     EXPECT_EQ(3, ssd->getAddr());
 }
 
-TEST_F(SSDTest, ArgparseWrite)
+TEST_F(BufferedSSDTest, ArgparseWrite)
 {
     string cmd = buildCommand("W", 3, VALID_HEX_DATA);
     ssd->parseCommand(cmd);
@@ -96,86 +270,71 @@ TEST_F(SSDTest, ArgparseWrite)
     EXPECT_EQ("0x1298CDEF", ssd->getValue());
 }
 
-TEST_F(SSDTest, ArgparseInvalidOp)
+TEST_F(BufferedSSDTest, ArgparseInvalidOp)
 {
     string cmd = buildCommand("S", 3);
     ssd->parseCommand(cmd);
     EXPECT_TRUE(checkOutputFile("ERROR"));
 }
 
-TEST_F(SSDTest, ArgparseInvalidAddr)
+TEST_F(BufferedSSDTest, ArgparseInvalidAddr)
 {
     string cmd = buildCommand("R", 300);
     ssd->parseCommand(cmd);
     EXPECT_TRUE(checkOutputFile("ERROR"));
 }
 
-TEST_F(SSDTest, ArgparseInvalidValue)
+TEST_F(BufferedSSDTest, ArgparseInvalidValue)
 {
     string cmd = buildCommand("W", 3, INVALID_HEX_DATA);
     ssd->parseCommand(cmd);
     EXPECT_TRUE(checkOutputFile("ERROR"));
 }
 
-TEST_F(SSDTest, WritePass) {
+TEST_F(BufferedSSDTest, WritePass) {
     bool isPass = writeCmd.run(VALID_TEST_ADDRESS, VALID_HEX_DATA);
     EXPECT_TRUE(isPass);
 }
 
-TEST_F(SSDTest, WriteFailWithOutOfAddressRange) {
+TEST_F(BufferedSSDTest, WriteFailWithOutOfAddressRange) {
     bool isPass = writeCmd.run(INVALID_TEST_ADDRESS, VALID_HEX_DATA);
     EXPECT_FALSE(isPass);
 }
 
 
-TEST_F(SSDTest, WriteInvalidData00) {
+TEST_F(BufferedSSDTest, WriteInvalidData00) {
 
     string invalidData = "0x1234567890000";
     bool isPass = writeCmd.run(VALID_TEST_ADDRESS, invalidData);
     EXPECT_FALSE(isPass);
 }
 
-TEST_F(SSDTest, WriteInvalidData01) {
+TEST_F(BufferedSSDTest, WriteInvalidData01) {
 
     string invalidData = "0x1234";
     bool isPass = writeCmd.run(VALID_TEST_ADDRESS, invalidData);
     EXPECT_FALSE(isPass);
 }
 
-TEST_F(SSDTest, WriteInvalidData02) {
+TEST_F(BufferedSSDTest, WriteInvalidData02) {
 
     string invalidData = "12345678";
     bool isPass = writeCmd.run(VALID_TEST_ADDRESS, invalidData);
     EXPECT_FALSE(isPass);
 }
 
-TEST_F(SSDTest, WriteInvalidData03) {
+TEST_F(BufferedSSDTest, WriteInvalidData03) {
 
     string invalidData = "0x1234ABzE";
     bool isPass = writeCmd.run(VALID_TEST_ADDRESS, invalidData);
     EXPECT_FALSE(isPass);
 }
 
-TEST_F(SSDTest, WriteInvalidData04) {
+TEST_F(BufferedSSDTest, WriteInvalidData04) {
 
     string invalidData = "0xA5CCH012";
     bool isPass = writeCmd.run(VALID_TEST_ADDRESS, invalidData);
     EXPECT_FALSE(isPass);
-}
-
-TEST_F(SSDTest, WriteReadVerify00) {
-
-    bool isPass = readCmd.run(VALID_TEST_ADDRESS);
-
-    EXPECT_EQ(true, isPass);
-    EXPECT_TRUE(checkOutputFile(INITIAL_HEX_DATA));
-
-    isPass = writeCmd.run(VALID_TEST_ADDRESS, VALID_HEX_DATA);
-    EXPECT_TRUE(isPass);
-
-    isPass = readCmd.run(VALID_TEST_ADDRESS);
-    EXPECT_EQ(true, isPass);
-    EXPECT_TRUE(checkOutputFile(VALID_HEX_DATA));
 }
 
 #ifdef NDEBUG

--- a/SSD/SSD-DirtySweeper/ssd.cpp
+++ b/SSD/SSD-DirtySweeper/ssd.cpp
@@ -160,7 +160,18 @@ private:
 	}
 };
 
+// SSD Interface Class
 class SSD {
+public:
+	virtual bool parseCommand(string command) = 0;
+	virtual void exec() = 0;
+	virtual int getArgCount() = 0;
+	virtual string getOp() = 0;
+	virtual int getAddr() = 0;
+	virtual string getValue() = 0;
+};
+
+class RealSSD : public SSD {
 public:
 	bool parseCommand(string command) {
         if (!isValidCommand(command)) {
@@ -180,7 +191,8 @@ public:
 		if (op == "W")
 			setCommand(&writeCmd);
 
-		command->run(addr, value);
+		if (command != nullptr)
+			command->run(addr, value);
 	}
 
 	int getArgCount() {
@@ -278,3 +290,54 @@ private:
 
 	SSDCommand* command = nullptr;
 };
+
+
+// SSD Proxy Class
+class BufferedSSD : public SSD {
+public:
+	BufferedSSD() : ssd{ new RealSSD() } {}
+	bool parseCommand(string command) {
+		return ssd->parseCommand(command);
+	}
+	void exec() {
+		string operation = ssd->getOp();
+		if (operation == "R") read();
+		if (operation == "W") write();
+		if (operation == "E") erase();	
+	}
+	int getArgCount() {
+		return ssd->getArgCount();
+	}
+	string getOp() {
+		return ssd->getOp();
+	}
+	int getAddr() {
+		return ssd->getAddr();
+	}
+	string getValue() {
+		return ssd->getValue();
+	}
+private:
+	// Buffered SSD methods
+	void read() {
+		// Check buffer first
+		// if buffer is empty, read from RealSSD
+		ssd->exec(); // read from RealSSD
+	}
+
+	void write() {
+		// Check buffer first
+		// if buffer is empty, read from RealSSD
+		ssd->exec(); // write to RealSSD
+	}
+
+	void erase() {
+		// Check buffer first
+		// if buffer is empty, read from RealSSD
+		ssd->exec(); // Erase RealSSD
+	}
+
+	RealSSD* ssd; // RealSSD instance
+
+};
+


### PR DESCRIPTION
## 수정 사항
- 기존 SSD Class 를 RealSSD 로 이름 변경
- 기존 SSD Class 의 public 함수들을 순수 가상함수로 가지고 있는 Interface class 작성(SSD)
- RealSSD 를 Instance 로 받아 Buffered SSD 를 작성 (Proxy pattern)
- BufferedSSD Class 내에서 Buffer 관련 동작 처리 위한 Private 함수 작성 
- 기존 TC 들의 SSD class 를 RealSSD class 로 변경

## 확인 사항
- 기존 TC 들 정상 동작 확인
- TC 의 class 를 RealSSD 에서 BufferedSSD 로 변경시에도 정상 Pass 확인(현재는 Buffer 처리 동작이 없기 때문에)
