### PR TITLE
Refactor  SSD TC : Not using command class directly

### DIFF
--- a/SSD/SSD-DirtySweeper/main.cpp
+++ b/SSD/SSD-DirtySweeper/main.cpp
@@ -9,7 +9,6 @@ using std::string;
 class RealSSDTest : public ::testing::Test {
 public:
     SSD* ssd = new RealSSD();
-    WriteCommand writeCmd;
     EraseCommand eraseCmd;
     string VALID_HEX_DATA = "0x1298CDEF";
     string INVALID_HEX_DATA = "0xABCDEFGH";
@@ -21,7 +20,6 @@ public:
     static const int INVALID_TEST_SIZE = 20;
 
 	static const int DELAY_NANOS_FOR_WRITE = 10000; // 10 millisecond
-
 
     void SetUp() override {
         ofstream file(FileNames::DATA_FILE);
@@ -136,48 +134,52 @@ TEST_F(RealSSDTest, ArgparseInvalidValue)
 }
 
 TEST_F(RealSSDTest, WritePass) {
-    bool isPass = writeCmd.run(VALID_TEST_ADDRESS, VALID_HEX_DATA);
+    string cmd = buildCommand("W", VALID_TEST_ADDRESS, VALID_HEX_DATA);
+    ssd->parseCommand(cmd);
+	bool isPass = ssd->exec();
     EXPECT_TRUE(isPass);
 }
 
 TEST_F(RealSSDTest, WriteFailWithOutOfAddressRange) {
-    bool isPass = writeCmd.run(INVALID_TEST_ADDRESS, VALID_HEX_DATA);
+    string cmd = buildCommand("W", INVALID_TEST_ADDRESS, VALID_HEX_DATA);
+    ssd->parseCommand(cmd);
+    bool isPass = ssd->exec();
     EXPECT_FALSE(isPass);
 }
 
 
 TEST_F(RealSSDTest, WriteInvalidData00) {
-
-    string invalidData = "0x1234567890000";
-    bool isPass = writeCmd.run(VALID_TEST_ADDRESS, invalidData);
+    string cmd = buildCommand("W", VALID_TEST_ADDRESS, "0x1234567890000");
+    ssd->parseCommand(cmd);
+    bool isPass = ssd->exec();
     EXPECT_FALSE(isPass);
 }
 
 TEST_F(RealSSDTest, WriteInvalidData01) {
-
-    string invalidData = "0x1234";
-    bool isPass = writeCmd.run(VALID_TEST_ADDRESS, invalidData);
+    string cmd = buildCommand("W", VALID_TEST_ADDRESS, "0x1234");
+    ssd->parseCommand(cmd);
+    bool isPass = ssd->exec();
     EXPECT_FALSE(isPass);
 }
 
 TEST_F(RealSSDTest, WriteInvalidData02) {
-
-    string invalidData = "12345678";
-    bool isPass = writeCmd.run(VALID_TEST_ADDRESS, invalidData);
+    string cmd = buildCommand("W", VALID_TEST_ADDRESS, "12345678");
+    ssd->parseCommand(cmd);
+    bool isPass = ssd->exec();
     EXPECT_FALSE(isPass);
 }
 
 TEST_F(RealSSDTest, WriteInvalidData03) {
-
-    string invalidData = "0x1234ABzE";
-    bool isPass = writeCmd.run(VALID_TEST_ADDRESS, invalidData);
+    string cmd = buildCommand("W", VALID_TEST_ADDRESS, "0x1234ABzE");
+    ssd->parseCommand(cmd);
+    bool isPass = ssd->exec();
     EXPECT_FALSE(isPass);
 }
 
 TEST_F(RealSSDTest, WriteInvalidData04) {
-
-    string invalidData = "0xA5CCH012";
-    bool isPass = writeCmd.run(VALID_TEST_ADDRESS, invalidData);
+    string cmd = buildCommand("W", VALID_TEST_ADDRESS, "0xA5CCH012");
+    ssd->parseCommand(cmd);
+    bool isPass = ssd->exec();
     EXPECT_FALSE(isPass);
 }
 
@@ -189,9 +191,12 @@ TEST_F(RealSSDTest, WriteReadVerify00) {
     EXPECT_EQ(true, isPass);
     EXPECT_TRUE(checkOutputFile(INITIAL_HEX_DATA));
 
-    isPass = writeCmd.run(VALID_TEST_ADDRESS, VALID_HEX_DATA);
+    cmd = buildCommand("W", VALID_TEST_ADDRESS, VALID_HEX_DATA);
+    ssd->parseCommand(cmd);
+    isPass = ssd->exec();
     EXPECT_TRUE(isPass);
 
+    cmd = buildCommand("R", VALID_TEST_ADDRESS);
     ssd->parseCommand(cmd);
     isPass = ssd->exec();
     EXPECT_EQ(true, isPass);
@@ -219,7 +224,9 @@ TEST_F(RealSSDTest, EraseFailExceedMaxSize) {
 }
 
 TEST_F(RealSSDTest, EraseAndReadVerify) {
-    bool isPass = writeCmd.run(VALID_TEST_ADDRESS, VALID_HEX_DATA);
+    string cmd = buildCommand("W", VALID_TEST_ADDRESS, VALID_HEX_DATA);
+    ssd->parseCommand(cmd);
+    bool isPass = ssd->exec();
     EXPECT_TRUE(isPass);
 
     isPass = eraseCmd.run(VALID_TEST_ADDRESS, VALID_HEX_DATA, VALID_TEST_SIZE);

--- a/SSD/SSD-DirtySweeper/main.cpp
+++ b/SSD/SSD-DirtySweeper/main.cpp
@@ -18,7 +18,7 @@ public:
     static const int VALID_TEST_SIZE = 10;
     static const int INVALID_TEST_SIZE = 20;
 
-	static const int DELAY_NANOS_FOR_WRITE = 10000; // 10 millisecond
+	static const int DELAY_NANOS_FOR_WRITE = 1000000; // 10 millisecond
 
     void SetUp() override {
         ofstream file(FileNames::DATA_FILE);
@@ -197,6 +197,8 @@ TEST_F(RealSSDTest, WriteReadVerify00) {
     ssd->parseCommand(cmd);
     bool isPass = ssd->exec();
 
+    this_thread::sleep_for(chrono::nanoseconds(DELAY_NANOS_FOR_WRITE));
+
     EXPECT_EQ(true, isPass);
     EXPECT_TRUE(checkOutputFile(INITIAL_HEX_DATA));
 
@@ -204,6 +206,8 @@ TEST_F(RealSSDTest, WriteReadVerify00) {
     ssd->parseCommand(cmd);
     isPass = ssd->exec();
     EXPECT_TRUE(isPass);
+
+    this_thread::sleep_for(chrono::nanoseconds(DELAY_NANOS_FOR_WRITE));
 
     cmd = buildCommand("R", VALID_TEST_ADDRESS);
     ssd->parseCommand(cmd);

--- a/SSD/SSD-DirtySweeper/main.cpp
+++ b/SSD/SSD-DirtySweeper/main.cpp
@@ -49,10 +49,9 @@ public:
         return true;
     }
 
-    string buildCommand(string rwe, int lba, string data = "", int test_size = 0) {
-        string cmdLine = rwe + " " + std::to_string(lba);
-        if (rwe == "W") cmdLine = cmdLine + " " + data;
-		if (rwe == "E") cmdLine = cmdLine + " " + std::to_string(test_size);
+    string buildCommand(string cmd, int lba, string data = "") {
+        string cmdLine = cmd + " " + std::to_string(lba);
+        if (cmd == "W" || cmd == "E") cmdLine = cmdLine + " " + data;
         return cmdLine;
     }
 };
@@ -114,7 +113,7 @@ TEST_F(RealSSDTest, ArgparseWrite)
 
 TEST_F(RealSSDTest, ArgparseErase)
 {
-    string cmd = buildCommand("E", 3, VALID_HEX_DATA, 10);
+    string cmd = buildCommand("E", 3, std::to_string(10));
     ssd->parseCommand(cmd);
     EXPECT_EQ(3, ssd->getArgCount());
     EXPECT_EQ("E", ssd->getOp());
@@ -214,28 +213,28 @@ TEST_F(RealSSDTest, WriteReadVerify00) {
 }
 
 TEST_F(RealSSDTest, ErasePass) {
-    string cmd = buildCommand("E", VALID_TEST_ADDRESS, VALID_HEX_DATA, VALID_TEST_SIZE);
+    string cmd = buildCommand("E", VALID_TEST_ADDRESS, to_string(VALID_TEST_SIZE));
 	ssd->parseCommand(cmd);
     bool isPass = ssd->exec();
     EXPECT_TRUE(isPass);
 }
 
 TEST_F(RealSSDTest, EraseFailOutofRange) {
-    string cmd = buildCommand("E", INVALID_TEST_ADDRESS, VALID_HEX_DATA, VALID_TEST_SIZE);
+    string cmd = buildCommand("E", INVALID_TEST_ADDRESS, to_string(VALID_TEST_SIZE));
     ssd->parseCommand(cmd);
     bool isPass = ssd->exec();
     EXPECT_FALSE(isPass);
 }
 
 TEST_F(RealSSDTest, EraseFailOutofRangeDestination) {
-    string cmd = buildCommand("E", VALID_TEST_ADDRESS_MAX, VALID_HEX_DATA, VALID_TEST_SIZE);
+    string cmd = buildCommand("E", VALID_TEST_ADDRESS_MAX, to_string(VALID_TEST_SIZE));
     ssd->parseCommand(cmd);
     bool isPass = ssd->exec();
     EXPECT_FALSE(isPass);
 }
 
 TEST_F(RealSSDTest, EraseFailExceedMaxSize) {
-    string cmd = buildCommand("E", VALID_TEST_ADDRESS, VALID_HEX_DATA, INVALID_TEST_SIZE);
+    string cmd = buildCommand("E", VALID_TEST_ADDRESS, to_string(INVALID_TEST_SIZE));
     ssd->parseCommand(cmd);
     bool isPass = ssd->exec();
     EXPECT_FALSE(isPass);
@@ -248,7 +247,7 @@ TEST_F(RealSSDTest, EraseAndReadVerify) {
 
     this_thread::sleep_for(chrono::nanoseconds(DELAY_NANOS_FOR_WRITE));
 
-    ssd->parseCommand(buildCommand("E", VALID_TEST_ADDRESS, VALID_HEX_DATA, VALID_TEST_SIZE));
+    ssd->parseCommand(buildCommand("E", VALID_TEST_ADDRESS, to_string(VALID_TEST_SIZE)));
     isPass = ssd->exec();
     EXPECT_TRUE(isPass);
 

--- a/SSD/SSD-DirtySweeper/ssd.cpp
+++ b/SSD/SSD-DirtySweeper/ssd.cpp
@@ -344,6 +344,10 @@ public:
 	string getValue() {
 		return ssd->getValue();
 	}
+	int getSize() {
+		return ssd->getSize();
+	}
+
 private:
 	// Buffered SSD methods
 	bool read() {

--- a/SSD/SSD-DirtySweeper/ssd.cpp
+++ b/SSD/SSD-DirtySweeper/ssd.cpp
@@ -180,6 +180,7 @@ public:
 	virtual string getOp() = 0;
 	virtual int getAddr() = 0;
 	virtual string getValue() = 0;
+	virtual int getSize() = 0;
 };
 
 class RealSSD : public SSD {
@@ -225,6 +226,10 @@ public:
 
 	string getValue() {
 		return value;
+	}
+
+	int getSize() {
+		return size;
 	}
 
 private:

--- a/SSD/SSD-DirtySweeper/ssd.cpp
+++ b/SSD/SSD-DirtySweeper/ssd.cpp
@@ -175,7 +175,7 @@ private:
 class SSD {
 public:
 	virtual bool parseCommand(string command) = 0;
-	virtual void exec() = 0;
+	virtual bool exec() = 0;
 	virtual int getArgCount() = 0;
 	virtual string getOp() = 0;
 	virtual int getAddr() = 0;
@@ -193,7 +193,7 @@ public:
         return true;
 	}
 
-	void exec() {
+	bool exec() {
 		ReadCommand readCmd;
 		WriteCommand writeCmd;
 		EraseCommand eraseCmd;
@@ -206,9 +206,9 @@ public:
 			setCommand(&eraseCmd);
 
 		if (command == nullptr)
-			return;
+			return false;
 
-		command->run(addr, value, size);
+		return command->run(addr, value, size);
 	}
 
 	int getArgCount() {
@@ -321,11 +321,11 @@ public:
 	bool parseCommand(string command) {
 		return ssd->parseCommand(command);
 	}
-	void exec() {
+	bool exec() {
 		string operation = ssd->getOp();
-		if (operation == "R") read();
-		if (operation == "W") write();
-		if (operation == "E") erase();	
+		if (operation == "R") return read();
+		if (operation == "W") return write();
+		if (operation == "E") return erase();	
 	}
 	int getArgCount() {
 		return ssd->getArgCount();
@@ -341,24 +341,24 @@ public:
 	}
 private:
 	// Buffered SSD methods
-	void read() {
+	bool read() {
 		// Check buffer first
 		// if buffer is empty, read from RealSSD
-		ssd->exec(); // read from RealSSD
+		return ssd->exec(); // read from RealSSD
 	}
 
-	void write() {
+	bool write() {
 		// check if buffer is full, flush to RealSSD
 		// check if command can be merged with buffer
 		// if buffer has room, write to buffer
-		ssd->exec(); // write to RealSSD
+		return ssd->exec(); // write to RealSSD
 	}
 
-	void erase() {
+	bool erase() {
 		// check if buffer is full, flush to RealSSD
 		// check if command can be merged with buffer
 		// if buffer has room, write to buffer
-		ssd->exec(); // Erase RealSSD
+		return ssd->exec(); // Erase RealSSD
 	}
 
 	RealSSD* ssd; // RealSSD instance


### PR DESCRIPTION
SSD TC 가 Command class instance 를 직접 사용하고 있어 refactoring 진행 했습니다. 
## 수정사항
- Command instance 삭제 및 TC 수정
- BufferSSD 에 getSize 함수가 누락되어 추가
- TC 를 위한 Command String 빌더에 Erase case 추가
- Command Parser TC Erase case  추가
