### PR TITLE
Make FileIO as Singleton

### DIFF
--- a/SSD/SSD-DirtySweeper/ssd.cpp
+++ b/SSD/SSD-DirtySweeper/ssd.cpp
@@ -19,8 +19,21 @@ namespace FileNames {
     const std::string OUTPUT_FILE = "ssd_output.txt";
 }
 
+
+// Singleton FileControl Class
+// ex : FileControl& file = FileControl::get_instance();
 class FileControl {
+private:
+	FileControl() {}
+	FileControl(const FileControl& c) = delete;
+	FileControl& operator=(const FileControl&) = delete;
+
 public:
+	static FileControl& get_instance() {
+		static FileControl instance;
+		return instance;
+	}
+	
 	void updateOutput(const string& msg) {
 		ofstream fout(FileNames::OUTPUT_FILE);
 		fout << msg;
@@ -76,7 +89,7 @@ protected:
 	}
 
 	vector<string> ssdData;
-	FileControl file;
+	FileControl& file = FileControl::get_instance();
 };
 
 class ReadCommand : public SSDCommand {
@@ -187,7 +200,7 @@ public:
     virtual int getAccessCount() = 0;
     virtual void bufferClear() = 0;
 protected:
-	FileControl file;
+	FileControl& file = FileControl::get_instance();
 };
 
 class RealSSD : public SSD {


### PR DESCRIPTION
File Control class 가 여러 class 에서 사용되면서 다른 Class 들이 생성될 때마다 object 가 만들어지면서 memory 가 낭비되고 있습니다. 
하나의 object 로 관리되면 좋을 것 같아 SIngletone 을 만들었습니다. 