### PR TITLE
[Design Pattern] SSD Command 에 Simple Factory 패턴 적용

### DIFF
--- a/SSD/SSD-DirtySweeper/command.cpp
+++ b/SSD/SSD-DirtySweeper/command.cpp
@@ -74,3 +74,14 @@ private:
 		return true;
 	}
 };
+
+// Simple Factory for SSD Command
+class SSDCommandFactory {
+public:
+	SSDCommand* getCommand(string cmdType) {
+		if (cmdType == "R") return new ReadCommand();
+		if (cmdType == "W") return new WriteCommand();
+		if (cmdType == "E") return new EraseCommand();
+		return nullptr;
+	}
+};

--- a/SSD/SSD-DirtySweeper/main.cpp
+++ b/SSD/SSD-DirtySweeper/main.cpp
@@ -6,15 +6,9 @@
 using std::string;
 
 class RealSSDTest : public ::testing::Test {
-protected:    
-    std::unique_ptr<SSD> ssd;
-
 public:
-    RealSSDTest() {
-        if (!ssd) {
-            ssd = std::make_unique<RealSSD>();
-        }
-    }
+    RealSSDTest() : ssd {new RealSSD } { }
+    SSD* ssd;
 
     string VALID_HEX_DATA = "0x1298CDEF";
     string INVALID_HEX_DATA = "0xABCDEFGH";
@@ -257,16 +251,10 @@ TEST_F(RealSSDTest, EraseAndReadVerify) {
 
 ///////////////////////////////////////////////////////////////////////////
 class BufSSDTest : public RealSSDTest {
-protected:
-    std::unique_ptr<SSD> ssd;
-
 public:
-    BufSSDTest() {
-        if (!ssd) {
-            ssd = std::make_unique<BufferedSSD>();
-        }
-    }
- 
+    BufSSDTest() : ssd { new BufferedSSD } { }
+    SSD* ssd;
+
     string PRECONDITION_HEX_DATA = "0xABCDA5A5";
     
     string cmd;

--- a/SSD/SSD-DirtySweeper/ssd.cpp
+++ b/SSD/SSD-DirtySweeper/ssd.cpp
@@ -43,23 +43,10 @@ public:
 	}
 
 	bool exec() {
-		ReadCommand readCmd;
-		WriteCommand writeCmd;
-		EraseCommand eraseCmd;
+		command = factory.getCommand(op);
+		if (command == nullptr) return false;
 
-		if (op == "R")
-			setCommand(&readCmd);
-        if (op == "W") {
-            setCommand(&writeCmd);
-            accessCount++;
-        }
-        if (op == "E") {
-            setCommand(&eraseCmd);
-            accessCount += size;
-        }
-
-		if (command == nullptr)
-			return false;
+		UpdateAccessCount(op);
 
 		return command->run(addr, value, size);
 	}
@@ -187,8 +174,10 @@ private:
 		return ((ch >= '0') && (ch <= '9'));
 	}
 
-	void setCommand(SSDCommand* cmd) {
-		command = cmd;
+	void UpdateAccessCount(const string& cmd)
+	{
+		if (cmd == "W") accessCount++;
+		if (cmd == "E") accessCount += size;
 	}
 
 	int argCount;
@@ -199,6 +188,7 @@ private:
     int accessCount;
 
 	SSDCommand* command = nullptr;
+	SSDCommandFactory factory;
 };
 
 // SSD Proxy Class


### PR DESCRIPTION
## 수정사항
 - SSD Command 에 Simple Factory 패턴 적용
 - Buffered SSD Test Fixture 가 Real SSD Test Fixture 를 상속받게 하여 중복 코드 삭제
 - 불필요한 Delay 코드 삭제